### PR TITLE
Update build.sh

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 NOT='.sh$|^.git|.jsx$|.js$|^tests|^.eslint|^.travis|^package.json$|^package-lock.json$|^.prettierrc'
 DIST=dist
 VENDOR_DIR=$DIST/content/vendor


### PR DESCRIPTION
When I try to build you project on debian, it always fails to run build.sh, as it uses bash syntax, but identifies as sh script.