### PR TITLE
Add tests for Quoting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: node_js
 node_js:
-- 12
+- 14

--- a/addon/content/es-modules/quoting.js
+++ b/addon/content/es-modules/quoting.js
@@ -1,0 +1,25 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/*
+ * This is a temporary wrapper. Privileged code doesn't allow es-modules, but
+ * eventually all components should be exported as es-modules. This code
+ * "re-exports" globals as es-modules, which enables them to be imported
+ * (e.g. for tests) or used as globals.
+ *
+ * When the switch to a WebExtension is done, the actual code should be migrated
+ * here and the global variable workarounds should be removed.
+ */
+
+/* globals require */
+
+// Set up an object for the make-shift module emulation
+window.esExports = {};
+
+// The node.js `esm` loader won't share globals. Since this is only used
+// by tests at the moment, which are run by node.js, use the `require`
+// function as a fallback
+require("../quoting.js");
+
+export const Quoting = window.esExports.Quoting;

--- a/addon/content/quoting.js
+++ b/addon/content/quoting.js
@@ -7,7 +7,7 @@
 /* exported Quoting */
 
 class _Quoting {
-  canInclude(aNode) {
+  _canInclude(aNode) {
     let v =
       aNode.tagName?.toLowerCase() == "br" ||
       (aNode.nodeType == aNode.TEXT_NODE && aNode.textContent.trim() === "");
@@ -15,7 +15,7 @@ class _Quoting {
     return v;
   }
 
-  isBody(aNode) {
+  _isBody(aNode) {
     if (aNode.tagName?.toLowerCase() == "body") {
       return true;
     }
@@ -34,24 +34,24 @@ class _Quoting {
       }
     }
     // dump(count+"\n");
-    return count == 1 && this.isBody(aNode.parentNode);
+    return count == 1 && this._isBody(aNode.parentNode);
   }
 
-  implies(a, b) {
+  _implies(a, b) {
     return !a || (a && b);
   }
 
   /* Create a blockquote that encloses everything relevant, starting from marker.
    * Marker is included by default, remove it later if you need to. */
-  encloseInBlockquote(aDoc, marker) {
-    if (marker.previousSibling && this.canInclude(marker.previousSibling)) {
-      this.encloseInBlockquote(aDoc, marker.previousSibling);
-    } else if (!marker.previousSibling && !this.isBody(marker.parentNode)) {
-      this.encloseInBlockquote(aDoc, marker.parentNode);
+  _encloseInBlockquote(aDoc, marker) {
+    if (marker.previousSibling && this._canInclude(marker.previousSibling)) {
+      this._encloseInBlockquote(aDoc, marker.previousSibling);
+    } else if (!marker.previousSibling && !this._isBody(marker.parentNode)) {
+      this._encloseInBlockquote(aDoc, marker.parentNode);
     } else if (
-      this.implies(
+      this._implies(
         marker == marker.parentNode.firstChild,
-        !this.isBody(marker.parentNode)
+        !this._isBody(marker.parentNode)
       )
     ) {
       let blockquote = aDoc.createElement("blockquote");
@@ -63,10 +63,10 @@ class _Quoting {
     }
   }
 
-  trySel(aDoc, sel, remove) {
+  _trySel(aDoc, sel, remove) {
     let marker = aDoc.querySelector(sel);
     if (marker) {
-      this.encloseInBlockquote(aDoc, marker);
+      this._encloseInBlockquote(aDoc, marker);
       if (remove) {
         marker.remove();
       }
@@ -78,7 +78,7 @@ class _Quoting {
   convertHotmailQuotingToBlockquote1(aDoc) {
     /* We make the assumption that no one uses a <hr> in their emails except for
      * separating a quoted message from the rest */
-    this.trySel(
+    this._trySel(
       aDoc,
       "body > hr, \
        body > div > hr, \
@@ -90,13 +90,13 @@ class _Quoting {
   }
 
   convertMiscQuotingToBlockquote(aDoc) {
-    this.trySel(aDoc, ".yahoo_quoted");
+    this._trySel(aDoc, ".yahoo_quoted");
   }
 
   /* There's a special message header for that. */
   convertOutlookQuotingToBlockquote(aWin, aDoc) {
     /* Outlook uses a special thing for that */
-    this.trySel(aDoc, ".OutlookMessageHeader");
+    this._trySel(aDoc, ".OutlookMessageHeader");
     for (let div of aDoc.getElementsByTagName("div")) {
       let style = aWin.getComputedStyle(div);
       if (
@@ -107,7 +107,7 @@ class _Quoting {
         style.borderRightWidth == "0px" &&
         style.borderBottomWidth == "0px"
       ) {
-        this.encloseInBlockquote(aDoc, div);
+        this._encloseInBlockquote(aDoc, div);
         div.style.borderTopWidth = 0;
         break;
       }
@@ -140,7 +140,7 @@ class _Quoting {
           child.parentNode.insertBefore(tn1, child);
           child.parentNode.insertBefore(tn2, child);
           child.remove();
-          this.encloseInBlockquote(aDoc, tn2);
+          this._encloseInBlockquote(aDoc, tn2);
           let ex = new Error();
           ex.found = true;
           throw ex;
@@ -204,3 +204,12 @@ class _Quoting {
 }
 
 var Quoting = new _Quoting();
+
+// This is temporary code to allow using using this as both
+// an es-module and as-is with global variables. This code
+// should be removed when the transition to a WebExtension is
+// complete.
+
+if (window.esExports) {
+  window.esExports.Quoting = Quoting;
+}

--- a/addon/content/quoting.js
+++ b/addon/content/quoting.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-/* Below are hacks^W heuristics for finding quoted parts in a given email */
+/* Below are hacks heuristics for finding quoted parts in a given email */
 
 /* exported Quoting */
 
@@ -196,7 +196,7 @@ class _Quoting {
           blockquote.parentNode.removeChild(next);
           blockquotes.delete(next);
         } else {
-          Cu.reportError("What?!");
+          console.warn("What?!");
         }
       }
     }

--- a/addon/content/stub.compose-ui.js
+++ b/addon/content/stub.compose-ui.js
@@ -87,7 +87,7 @@ function registerQuickReply() {
         Log.debug("onDraftChanged", Conversations == mainWindow.Conversations);
         switch (aTopic) {
           case "modified":
-            newComposeSessionByDraftIf().catch(Cu.reportError);
+            newComposeSessionByDraftIf().catch(console.warn);
             break;
           case "removed":
             getActiveEditor().value = "";
@@ -249,7 +249,7 @@ function editFields(aFocusId) {
 
 function confirmDiscard(event) {
   if (!startedEditing() || confirm(strings.get("confirmDiscard"))) {
-    onDiscard().catch(Cu.reportError);
+    onDiscard().catch(console.warn);
   }
 }
 
@@ -1294,7 +1294,7 @@ function createStateListener(aComposeSession, aMsgHdrs, aId) {
         //  params might have changed in the meanwhile.
         if (aId) {
           SimpleStorage.remove(SIMPLE_STORAGE_TABLE_NAME, aId).catch(
-            Cu.reportError
+            console.warn
           );
         }
         // Do stuff to the message we replied to.

--- a/addon/tests/quoting.test.js
+++ b/addon/tests/quoting.test.js
@@ -27,19 +27,19 @@ const samples = {
           </style>
 
           <div class="moz-text-html" lang="x-western">
-            <div style="font-family: Calibri, Helvetica, sans-serif; font-size: 12pt; color: rgb(0, 0, 0)">This is really good to hear</div>
-            <div style="font-family: Calibri, Helvetica, sans-serif; font-size: 12pt; color: rgb(0, 0, 0)">
+            <div>This is really good to hear</div>
+            <div>
               <br />
             </div>
-            <div style="font-family: Calibri, Helvetica, sans-serif; font-size: 12pt; color: rgb(0, 0, 0)">Most likely going to move &nbsp;to meet you and catch up.</div>
-            <div style="font-family: Calibri, Helvetica, sans-serif; font-size: 12pt; color: rgb(0, 0, 0)">
+            <div>Most likely going to move &nbsp;to meet you and catch up.</div>
+            <div>
               <br />
             </div>
-            <div style="font-family: Calibri, Helvetica, sans-serif; font-size: 12pt; color: rgb(0, 0, 0)">Best Regards,&nbsp;</div>
-            <div style="font-family: Calibri, Helvetica, sans-serif; font-size: 12pt; color: rgb(0, 0, 0)">
+            <div>Best Regards,&nbsp;</div>
+            <div>
               <br />
             </div>
-            <div style="font-family: Calibri, Helvetica, sans-serif; font-size: 12pt; color: rgb(0, 0, 0)">Someone</div>
+            <div>Someone</div>
             <div>
               <hr tabindex="-1" style="display: inline-block; width: 98%" />
               <div id="divRplyFwdMsg" dir="ltr">

--- a/addon/tests/quoting.test.js
+++ b/addon/tests/quoting.test.js
@@ -1,0 +1,250 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+/* eslint-env jest */
+
+// Standard imports for all tests
+const { esmImport } = require("./utils");
+
+// Prettier is used to normalize the html formatting so we can reliably use it to compare HTML with
+// text diffing.
+const prettier = require("prettier");
+
+// Import the components we want to test
+const { Quoting } = esmImport("../content/es-modules/quoting.js");
+
+const samples = {
+  hotmail: [
+    {
+      unquoted: `
+        <body dir="ltr">
+          <meta http-equiv="Content-Type" content="text/html; " />
+          <style type="text/css" style="display: none">
+            P {
+              margin-top: 0;
+              margin-bottom: 0;
+            }
+          </style>
+
+          <div class="moz-text-html" lang="x-western">
+            <div style="font-family: Calibri, Helvetica, sans-serif; font-size: 12pt; color: rgb(0, 0, 0)">This is really good to hear</div>
+            <div style="font-family: Calibri, Helvetica, sans-serif; font-size: 12pt; color: rgb(0, 0, 0)">
+              <br />
+            </div>
+            <div style="font-family: Calibri, Helvetica, sans-serif; font-size: 12pt; color: rgb(0, 0, 0)">Most likely going to move &nbsp;to meet you and catch up.</div>
+            <div style="font-family: Calibri, Helvetica, sans-serif; font-size: 12pt; color: rgb(0, 0, 0)">
+              <br />
+            </div>
+            <div style="font-family: Calibri, Helvetica, sans-serif; font-size: 12pt; color: rgb(0, 0, 0)">Best Regards,&nbsp;</div>
+            <div style="font-family: Calibri, Helvetica, sans-serif; font-size: 12pt; color: rgb(0, 0, 0)">
+              <br />
+            </div>
+            <div style="font-family: Calibri, Helvetica, sans-serif; font-size: 12pt; color: rgb(0, 0, 0)">Someone</div>
+            <div>
+              <hr tabindex="-1" style="display: inline-block; width: 98%" />
+              <div id="divRplyFwdMsg" dir="ltr">
+                <font style="font-size: 11pt" face="Calibri, sans-serif" color="#000000"
+                  ><b>From:</b> Someone &lt;xxx@gmail.com&gt;<br />
+                  <b>Sent:</b> September 8, 2019 12:42 PM<br />
+                  <b>To:</b> Other Person &lt;yyy@hotmail.com&gt;<br />
+                  <b>Subject:</b> Re: Thank You From the Bottom of My Heart</font
+                >
+                <div>&nbsp;</div>
+              </div>
+              <div class="BodyFragment">
+                <font size="2"
+                  ><span style="font-size: 11pt">
+                    <div class="PlainText">
+                      Hi Other Person! I'm so glad you're doing well. Your kind words mean a lot
+                      <br />
+                      to me.<br />
+                      <br />
+                      As you know :-).<br />
+                      <br />
+                      What will you do?<br />
+                      <br />
+                      &nbsp;&nbsp; XXX<br />
+                      <br />
+                      <br />
+                      <br />
+                      On 9/7/19 1:14 PM, Someone wrote:<br />
+                      &gt; Dear Dr.,<br />
+                      &gt; <br />
+                      &gt; I hope this email finds you very well,<br />
+                      &gt; <br />
+                    </div> </span
+                ></font>
+              </div>
+            </div>
+          </div>
+        </body>`,
+      quoted: `
+        <body dir="ltr">
+          <meta http-equiv="Content-Type" content="text/html; " />
+          <style type="text/css" style="display: none">
+            P {
+              margin-top: 0;
+              margin-bottom: 0;
+            }
+          </style>
+        
+          <div class="moz-text-html" lang="x-western">
+            <div style="font-family: Calibri, Helvetica, sans-serif; font-size: 12pt; color: rgb(0, 0, 0)">This is really good to hear</div>
+            <div style="font-family: Calibri, Helvetica, sans-serif; font-size: 12pt; color: rgb(0, 0, 0)">
+              <br />
+            </div>
+            <div style="font-family: Calibri, Helvetica, sans-serif; font-size: 12pt; color: rgb(0, 0, 0)">Most likely going to move &nbsp;to meet you and catch up.</div>
+            <div style="font-family: Calibri, Helvetica, sans-serif; font-size: 12pt; color: rgb(0, 0, 0)">
+              <br />
+            </div>
+            <div style="font-family: Calibri, Helvetica, sans-serif; font-size: 12pt; color: rgb(0, 0, 0)">Best Regards,&nbsp;</div>
+            <div style="font-family: Calibri, Helvetica, sans-serif; font-size: 12pt; color: rgb(0, 0, 0)">
+              <br />
+            </div>
+            <div style="font-family: Calibri, Helvetica, sans-serif; font-size: 12pt; color: rgb(0, 0, 0)">Someone</div>
+            <blockquote type="cite">
+              <div>
+                <div id="divRplyFwdMsg" dir="ltr">
+                  <font style="font-size: 11pt" face="Calibri, sans-serif" color="#000000"
+                    ><b>From:</b> Someone &lt;xxx@gmail.com&gt;<br />
+                    <b>Sent:</b> September 8, 2019 12:42 PM<br />
+                    <b>To:</b> Other Person &lt;yyy@hotmail.com&gt;<br />
+                    <b>Subject:</b> Re: Thank You From the Bottom of My Heart</font
+                  >
+                  <div>&nbsp;</div>
+                </div>
+                <div class="BodyFragment">
+                  <font size="2"
+                    ><span style="font-size: 11pt">
+                      <div class="PlainText">
+                        Hi Other Person! I'm so glad you're doing well. Your kind words mean a lot
+                        <br />
+                        to me.<br />
+                        <br />
+                        As you know :-).<br />
+                        <br />
+                        What will you do?<br />
+                        <br />
+                        &nbsp;&nbsp; XXX<br />
+                        <br />
+                        <br />
+                        <br />
+                        On 9/7/19 1:14 PM, Someone wrote:<br />
+                        &gt; Dear Dr.,<br />
+                        &gt; <br />
+                        &gt; I hope this email finds you very well,<br />
+                        &gt; <br />
+                      </div> </span
+                  ></font>
+                </div>
+              </div>
+            </blockquote>
+          </div>
+        </body>`,
+    },
+  ],
+  forward: [
+    {
+      unquoted: `<body>That's really interesting. Thanks for sharing.
+        <br><br>
+          -----Original Message-----<br>
+        From: abc@aol.com<br>
+        To: xxx@aol.com<br>
+        Sent: Sat, 20 Sep 2008 9:21 am<br>
+        Subject: Fwd: Did you ever wonder what happened to the guy?<br><br>
+
+        look at that!</body>
+          `,
+      quoted: `<body>
+      That's really interesting. Thanks for sharing.
+      <blockquote type="cite">
+      <br /><br />
+      -----Original Message-----<br />
+      From: abc@aol.com<br />
+      To: xxx@aol.com<br />
+      Sent: Sat, 20 Sep 2008 9:21 am<br />
+      Subject: Fwd: Did you ever wonder what happened to the guy?<br /><br />
+
+      look at that!
+      </blockquote>
+      </body>`,
+    },
+  ],
+  // Current outlook message parsing relies on `getComputedStyle`. There must be an alternative,
+  // but message samples are needed.
+  outlook: [
+    {
+      unquoted: `<body><p>Start of a message</p><div class="OutlookMessageHeader">From: abc@aol.com</div>
+      <div style="border-top: 1px solid rgb(181, 196, 223)">Some quoted stuff</div></body>`,
+      quoted: ``,
+    },
+  ],
+  disjoint: [
+    {
+      unquoted: `
+        <body>
+          <p>Start of message</p>
+          <blockquote>A first quote</blockquote>
+          <br />
+          <br />
+          <blockquote>A second quote</blockquote>
+          
+          <blockquote>A third quote<blockquote>with a quote inside</blockquote></blockquote>
+        </body>
+      `,
+      quoted: `
+        <body>
+          <p>Start of message</p>
+          <blockquote>
+            A first quote
+            <br />
+            <br />
+            A second quote A third quote
+            <blockquote>with a quote inside</blockquote>
+          </blockquote>
+        </body>
+      `,
+    },
+  ],
+};
+
+const PRETTIER_OPTS = { parser: "html", tabWidth: 0, printWidth: 120 };
+
+describe("Quoting test", () => {
+  test("Find quotes in Hotmail messages", async () => {
+    const parser = new DOMParser();
+    for (const { unquoted, quoted } of samples.hotmail) {
+      const doc = parser.parseFromString(unquoted, "text/html");
+      Quoting.convertHotmailQuotingToBlockquote1(doc);
+
+      const prettyQuoted = prettier.format(doc.body.outerHTML, PRETTIER_OPTS);
+      const prettyExpected = prettier.format(quoted, PRETTIER_OPTS);
+
+      expect(prettyQuoted).toBe(prettyExpected);
+    }
+  });
+  test("Find quotes in forwarded plain-text messages", async () => {
+    const parser = new DOMParser();
+    for (const { unquoted, quoted } of samples.forward) {
+      const doc = parser.parseFromString(unquoted, "text/html");
+      Quoting.convertForwardedToBlockquote(doc);
+
+      const prettyQuoted = prettier.format(doc.body.outerHTML, PRETTIER_OPTS);
+      const prettyExpected = prettier.format(quoted, PRETTIER_OPTS);
+
+      expect(prettyQuoted).toBe(prettyExpected);
+    }
+  });
+  test("Merge disjoint blockquotes", async () => {
+    const parser = new DOMParser();
+    for (const { unquoted, quoted } of samples.disjoint) {
+      const doc = parser.parseFromString(unquoted, "text/html");
+      Quoting.fusionBlockquotes(doc);
+
+      const prettyQuoted = prettier.format(doc.body.outerHTML, PRETTIER_OPTS);
+      const prettyExpected = prettier.format(quoted, PRETTIER_OPTS);
+
+      expect(prettyQuoted).toBe(prettyExpected);
+    }
+  });
+});

--- a/addon/tests/quoting.test.js
+++ b/addon/tests/quoting.test.js
@@ -89,19 +89,19 @@ const samples = {
           </style>
         
           <div class="moz-text-html" lang="x-western">
-            <div style="font-family: Calibri, Helvetica, sans-serif; font-size: 12pt; color: rgb(0, 0, 0)">This is really good to hear</div>
-            <div style="font-family: Calibri, Helvetica, sans-serif; font-size: 12pt; color: rgb(0, 0, 0)">
+            <div>This is really good to hear</div>
+            <div>
               <br />
             </div>
-            <div style="font-family: Calibri, Helvetica, sans-serif; font-size: 12pt; color: rgb(0, 0, 0)">Most likely going to move &nbsp;to meet you and catch up.</div>
-            <div style="font-family: Calibri, Helvetica, sans-serif; font-size: 12pt; color: rgb(0, 0, 0)">
+            <div>Most likely going to move &nbsp;to meet you and catch up.</div>
+            <div>
               <br />
             </div>
-            <div style="font-family: Calibri, Helvetica, sans-serif; font-size: 12pt; color: rgb(0, 0, 0)">Best Regards,&nbsp;</div>
-            <div style="font-family: Calibri, Helvetica, sans-serif; font-size: 12pt; color: rgb(0, 0, 0)">
+            <div>Best Regards,&nbsp;</div>
+            <div>
               <br />
             </div>
-            <div style="font-family: Calibri, Helvetica, sans-serif; font-size: 12pt; color: rgb(0, 0, 0)">Someone</div>
+            <div>Someone</div>
             <blockquote type="cite">
               <div>
                 <div id="divRplyFwdMsg" dir="ltr">


### PR DESCRIPTION
Add minimal tests for `Quoting` found in `quoting.js`. I don't have a good sample of different emails to pull from, so the tests consist of one real email and several made up ones. More should be added if someone has sample emails.

These APIs are called in exactly one place in `messageIFrame.jsx`. All methods could be consolidated to a single method `wrapBlockquotes` or something like that and then called once instead of being called in a sequence in `messageIFrame.jsx`.


All internal-use-only methods of `Quoting` have been prefixed with `_`. I think there are better ways to handle the quoting code. Right now it passes around a DOM and mutates it, which is no good if data needs to be passed between a webextension and the Thunderbird API. It would be nice if this turned into a string-based API, though I don't know the performance implications.

Also, I'm not sure how to test the `outlook` quoting method. It seems to rely on `getComputedStyle` which is only available for DOM nodes that are actually inserted into a real page. I don't have any samples of these types of messages, so I cannot analyze to find another way to do it.