### PR TITLE
Unwrap text dir Promise value

### DIFF
--- a/addon/content/conversationWrapper.jsx
+++ b/addon/content/conversationWrapper.jsx
@@ -16,10 +16,9 @@ class _ConversationWrapper extends React.PureComponent {
 
     // When moving to a WebExtension page this can simply be moved to CSS (see
     // options.css).
-    document.documentElement.setAttribute(
-      "dir",
-      browser.conversations.getLocaleDirection()
-    );
+    browser.conversations.getLocaleDirection().then((dir) => {
+      document.documentElement.setAttribute("dir", dir);
+    });
 
     this.props.dispatch(messageActions.waitForStartup());
   }


### PR DESCRIPTION
`getLocaleDirection()` returns a promise. It needs to be unwrapped before being assigned to an html attribute.