### PR TITLE
Merge thunks and actions into `summaryActions`

### DIFF
--- a/addon/content/attachments.jsx
+++ b/addon/content/attachments.jsx
@@ -276,7 +276,6 @@ export class Attachments extends React.PureComponent {
   showGalleryView() {
     this.props.dispatch(
       attachmentActions.showGalleryView({
-        type: "SHOW_GALLERY_VIEW",
         id: this.props.id,
       })
     );

--- a/addon/content/conversationHeader.jsx
+++ b/addon/content/conversationHeader.jsx
@@ -128,21 +128,23 @@ class _ConversationHeader extends React.PureComponent {
   }
 
   expandCollapse(event) {
-    this.props.dispatch({
-      type: "TOGGLE_CONVERSATION_EXPANDED",
-      expand: this.areSomeMessagesCollapsed,
-    });
+    this.props.dispatch(
+      messageActions.toggleConversationExpanded({
+        expand: this.areSomeMessagesCollapsed,
+      })
+    );
   }
 
   junkConversation(event) {
     // This callback is only activated when the conversation is not a
     //  conversation in a tab AND there's only one message in the conversation,
     //  i.e. the currently selected message
-    this.props.dispatch({
-      type: "MARK_AS_JUNK",
-      id: this.props.msgData[0].id,
-      isJunk: true,
-    });
+    this.props.dispatch(
+      messageActions.markAsJunk({
+        id: this.props.msgData[0].id,
+        isJunk: true,
+      })
+    );
   }
 
   // Mark the current conversation as read/unread. The conversation driver

--- a/addon/content/message.jsx
+++ b/addon/content/message.jsx
@@ -74,10 +74,11 @@ export class Message extends React.PureComponent {
         // this message. This should generally mean we get to scroll to the
         // right place most of the time.
         if (!this.props.iframesLoading) {
-          this.props.dispatch({
-            type: "CLEAR_SCROLLTO",
-            id: this.props.message.id,
-          });
+          this.props.dispatch(
+            messageActions.clearScrollto({
+              id: this.props.message.id,
+            })
+          );
         }
       });
     }
@@ -182,10 +183,12 @@ export class Message extends React.PureComponent {
         );
         break;
       case "o":
-        this.props.dispatch({
-          type: "MSG_EXPAND",
-          msgUri: this.props.message.msgUri,
-        });
+        this.props.dispatch(
+          messageActions.msgExpand({
+            msgUri: this.props.message.msgUri,
+            expand: !this.props.message.expanded,
+          })
+        );
         break;
       case "1":
       case "2":

--- a/addon/content/messageHeader.jsx
+++ b/addon/content/messageHeader.jsx
@@ -207,8 +207,7 @@ export class MessageHeader extends React.PureComponent {
     if (!this.props.expanded) {
       this.props.dispatch(
         messageActions.markAsRead({
-          expand: !this.props.expanded,
-          msgUri: this.props.msgUri,
+          id: this.props.id,
         })
       );
     }

--- a/addon/content/messageHeader.jsx
+++ b/addon/content/messageHeader.jsx
@@ -198,11 +198,12 @@ export class MessageHeader extends React.PureComponent {
   }
 
   onClickHeader() {
-    this.props.dispatch({
-      type: "MSG_EXPAND",
-      expand: !this.props.expanded,
-      msgUri: this.props.msgUri,
-    });
+    this.props.dispatch(
+      messageActions.msgExpand({
+        expand: !this.props.expanded,
+        msgUri: this.props.msgUri,
+      })
+    );
     if (!this.props.expanded) {
       this.props.dispatch({
         type: "MARK_AS_READ",

--- a/addon/content/messageHeader.jsx
+++ b/addon/content/messageHeader.jsx
@@ -205,11 +205,12 @@ export class MessageHeader extends React.PureComponent {
       })
     );
     if (!this.props.expanded) {
-      this.props.dispatch({
-        type: "MARK_AS_READ",
-        expand: !this.props.expanded,
-        msgUri: this.props.msgUri,
-      });
+      this.props.dispatch(
+        messageActions.markAsRead({
+          expand: !this.props.expanded,
+          msgUri: this.props.msgUri,
+        })
+      );
     }
   }
 

--- a/addon/content/messageNotification.jsx
+++ b/addon/content/messageNotification.jsx
@@ -136,11 +136,12 @@ class JunkNotification extends React.PureComponent {
   }
 
   onClick() {
-    this.props.dispatch({
-      type: "MARK_AS_JUNK",
-      isJunk: false,
-      id: this.props.id,
-    });
+    this.props.dispatch(
+      messageActions.markAsJunk({
+        isJunk: false,
+        id: this.props.id,
+      })
+    );
   }
 
   render() {

--- a/addon/content/modules/conversation.js
+++ b/addon/content/modules/conversation.js
@@ -24,6 +24,7 @@ XPCOMUtils.defineLazyModuleGetters(this, {
   setupLogging: "chrome://conversations/content/modules/misc.js",
   Services: "resource://gre/modules/Services.jsm",
   topMail3Pane: "chrome://conversations/content/modules/misc.js",
+  messageActions: "chrome://conversations/content/modules/misc.js",
 });
 
 XPCOMUtils.defineLazyGetter(this, "browser", function () {
@@ -392,10 +393,11 @@ Conversation.prototype = {
         (async () => {
           try {
             const msgData = await message.toReactData();
-            this.dispatch({
-              type: "MSG_UPDATE_DATA",
-              msgData,
-            });
+            this.dispatch(
+              messageActions.msgUpdateData({
+                msgData,
+              })
+            );
           } catch (ex) {
             if (ex.message != "Message no longer exists") {
               throw ex;
@@ -555,10 +557,11 @@ Conversation.prototype = {
     // from within a dispatch, then we have to dispatch this off to the main
     // thread.
     Services.tm.dispatchToMainThread(() => {
-      this.dispatch({
-        type: "REMOVE_MESSAGE_FROM_CONVERSATION",
-        msgUri: msg._uri,
-      });
+      this.dispatch(
+        messageActions.removeMessageFromConversation({
+          msgUri: msg._uri,
+        })
+      );
     });
   },
 

--- a/addon/content/modules/message.js
+++ b/addon/content/modules/message.js
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-"use strict";
-
 var EXPORTED_SYMBOLS = ["MessageFromGloda", "MessageFromDbHdr"];
 
 const { XPCOMUtils } = ChromeUtils.import(
@@ -22,6 +20,7 @@ XPCOMUtils.defineLazyModuleGetters(this, {
   parseMimeLine: "chrome://conversations/content/modules/misc.js",
   setupLogging: "chrome://conversations/content/modules/misc.js",
   Services: "resource://gre/modules/Services.jsm",
+  messageActions: "chrome://conversations/content/modules/misc.js",
 });
 
 XPCOMUtils.defineLazyGetter(this, "browser", function () {
@@ -356,20 +355,22 @@ class Message {
 
     const msgData = await this.toReactData();
     // TODO: make getting the window less ugly.
-    this._conversation._htmlPane.conversationDispatch({
-      type: "MSG_UPDATE_DATA",
-      msgData,
-    });
+    this._conversation._htmlPane.conversationDispatch(
+      messageActions.msgUpdateData({
+        msgData,
+      })
+    );
   }
 
   async setSmimeReload() {
     this.smimeReload = true;
     const msgData = await this.toReactData();
     // TODO: make getting the window less ugly.
-    this._conversation._htmlPane.conversationDispatch({
-      type: "MSG_UPDATE_DATA",
-      msgData,
-    });
+    this._conversation._htmlPane.conversationDispatch(
+      messageActions.msgUpdateData({
+        msgData,
+      })
+    );
   }
 
   // This function should be called whenever the message is selected
@@ -406,19 +407,21 @@ class Message {
   }
 
   addSpecialTag(tagDetails) {
-    this._conversation._htmlPane.conversationDispatch({
-      type: "MSG_ADD_SPECIAL_TAG",
-      tagDetails,
-      uri: this._uri,
-    });
+    this._conversation._htmlPane.conversationDispatch(
+      messageActions.msgAddSpecialTag({
+        tagDetails,
+        uri: this._uri,
+      })
+    );
   }
 
   removeSpecialTag(tagDetails) {
-    this._conversation._htmlPane.conversationDispatch({
-      type: "MSG_REMOVE_SPECIAL_TAG",
-      tagDetails,
-      uri: this._uri,
-    });
+    this._conversation._htmlPane.conversationDispatch(
+      messageActions.msgRemoveSpecialTag({
+        tagDetails,
+        uri: this._uri,
+      })
+    );
     // this._specialTags = this.specialTags.filter(t => t.name != tagDetails.name);
   }
 
@@ -555,10 +558,11 @@ class Message {
       this.isPhishing = true;
       const msgData = await this.toReactData();
       // TODO: make getting the window less ugly.
-      this._conversation._htmlPane.conversationDispatch({
-        type: "MSG_UPDATE_DATA",
-        msgData,
-      });
+      this._conversation._htmlPane.conversationDispatch(
+        messageActions.msgUpdateData({
+          msgData,
+        })
+      );
     }
   }
 

--- a/addon/content/modules/message.js
+++ b/addon/content/modules/message.js
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+"use strict";
+
 var EXPORTED_SYMBOLS = ["MessageFromGloda", "MessageFromDbHdr"];
 
 const { XPCOMUtils } = ChromeUtils.import(

--- a/addon/content/modules/misc.js
+++ b/addon/content/modules/misc.js
@@ -12,6 +12,7 @@ var EXPORTED_SYMBOLS = [
   "getMail3Pane",
   "msgUriToMsgHdr",
   "msgHdrGetUri",
+  "messageActions",
 ];
 
 const { XPCOMUtils } = ChromeUtils.import(
@@ -203,3 +204,16 @@ function msgUriToMsgHdr(aUri) {
 function msgHdrGetUri(aMsg) {
   return aMsg.folder.getUriForMsg(aMsg);
 }
+
+/**
+ * We cannot import `messageActions` directly, so we fake the actions object
+ * until all non-web extension code is removed
+ */
+var messageActions = new Proxy(
+  {},
+  {
+    get(target, prop) {
+      return (payload) => ({ type: `messages/${prop}`, payload });
+    },
+  }
+);

--- a/addon/content/modules/plugins/lightning.js
+++ b/addon/content/modules/plugins/lightning.js
@@ -11,6 +11,7 @@ const { XPCOMUtils } = ChromeUtils.import(
 XPCOMUtils.defineLazyModuleGetters(this, {
   registerHook: "chrome://conversations/content/modules/hook.js",
   topMail3Pane: "chrome://conversations/content/modules/misc.js",
+  messageActions: "chrome://conversations/content/modules/misc.js",
 });
 
 let hasLightning = false;
@@ -35,17 +36,18 @@ function imipOptions(msgWindow, msg, itipItem, rc, actionFunc, foundItems) {
       onOperationComplete(aCalendar, aStatus, aOperationType, aId, aDetail) {
         let label = cal.itip.getCompleteText(aStatus, aOperationType);
 
-        msg._conversation._htmlPane.conversationDispatch({
-          type: "MSG_SHOW_NOTIFICATION",
-          msgData: {
-            msgUri: msg._uri,
-            notification: {
-              iconName: "calendar_today",
-              label,
-              type: "lightning",
+        msg._conversation._htmlPane.conversationDispatch(
+          messageActions.msgShowNotification({
+            msgData: {
+              msgUri: msg._uri,
+              notification: {
+                iconName: "calendar_today",
+                label,
+                type: "lightning",
+              },
             },
-          },
-        });
+          })
+        );
 
         // In case it's useful
         listener.onOperationComplete(
@@ -101,18 +103,19 @@ function imipOptions(msgWindow, msg, itipItem, rc, actionFunc, foundItems) {
   }
 
   // Update the Conversation UI
-  msg._conversation._htmlPane.conversationDispatch({
-    type: "MSG_SHOW_NOTIFICATION",
-    msgData: {
-      msgUri: msg._uri,
-      notification: {
-        buttons,
-        iconName: "calendar_today",
-        label: data.label,
-        type: "lightning",
+  msg._conversation._htmlPane.conversationDispatch(
+    messageActions.msgShowNotification({
+      msgData: {
+        msgUri: msg._uri,
+        notification: {
+          buttons,
+          iconName: "calendar_today",
+          label: data.label,
+          type: "lightning",
+        },
       },
-    },
-  });
+    })
+  );
 }
 
 let lightningHook = {
@@ -127,17 +130,18 @@ let lightningHook = {
       let method = msgHdr.getStringProperty("imip_method");
       let label = cal.itip.getMethodText(method);
       cal.itip.initItemFromMsgData(itipItem, method, msgHdr);
-      msg._conversation._htmlPane.conversationDispatch({
-        type: "MSG_SHOW_NOTIFICATION",
-        msgData: {
-          msgUri: msg._uri,
-          notification: {
-            iconName: "calendar_today",
-            type: "lightning",
-            label,
+      msg._conversation._htmlPane.conversationDispatch(
+        messageActions.msgShowNotification({
+          msgData: {
+            msgUri: msg._uri,
+            notification: {
+              iconName: "calendar_today",
+              type: "lightning",
+              label,
+            },
           },
-        },
-      });
+        })
+      );
 
       cal.itip.processItipItem(
         itipItem,

--- a/addon/content/reducer-messages.js
+++ b/addon/content/reducer-messages.js
@@ -4,7 +4,7 @@
 
 /* global Conversations, Conversation, BrowserSim, topMail3Pane */
 
-import { summarySlice } from "./reducer-summary.js";
+import { summaryActions } from "./reducer-summary.js";
 
 const initialMessages = {
   msgData: [],
@@ -145,7 +145,7 @@ export const messageActions = {
       const isInTab = params.has("urls");
       const topWin = topMail3Pane(window);
       await dispatch(
-        summarySlice.actions.setConversationState({
+        summaryActions.setConversationState({
           isInTab,
           tabId: BrowserSim.getTabId(topWin, window),
           windowId: BrowserSim.getWindowId(topWin),
@@ -167,7 +167,7 @@ export const messageActions = {
         (await browser.conversations.getCorePref("mail.show_headers")) == 2;
 
       await dispatch(
-        summarySlice.actions.setSystemOptions({
+        summaryActions.setSystemOptions({
           browserForegroundColor,
           browserBackgroundColor,
           defaultDetailsShowing,

--- a/addon/content/reducer-summary.js
+++ b/addon/content/reducer-summary.js
@@ -45,25 +45,23 @@ async function handleShowDetails(messages, state, dispatch, updateFn) {
   }
 }
 
-export var summaryActions = {
+export const summaryActions = {
   replaceConversation({ summary, messages }) {
     return async (dispatch, getState) => {
       await handleShowDetails(messages, getState(), dispatch, () => {
         dispatch(summarySlice.actions.replaceSummaryDetails(summary));
-        return dispatch({
-          type: "REPLACE_CONVERSATION_DETAILS",
-          messages,
-        });
+        return dispatch(
+          messageActions.replaceConversationDetails({
+            messages,
+          })
+        );
       });
     };
   },
   appendMessages({ summary, messages }) {
     return async (dispatch, getState) => {
       await handleShowDetails(messages, getState(), dispatch, () => {
-        return dispatch({
-          type: "APPEND_MESSAGES",
-          messages,
-        });
+        return dispatch(messageActions.appendMessages({ messages }));
       });
     };
   },

--- a/addon/content/reducer-summary.js
+++ b/addon/content/reducer-summary.js
@@ -230,4 +230,9 @@ export const summarySlice = RTK.createSlice({
   },
 });
 
+// We don't really care about drawing a distinction between
+// actions and thunks, so we make the actions and thunks
+// available from the same object.
+Object.assign(summaryActions, summarySlice.actions);
+
 globalThis.conversationSummaryActions = summaryActions;

--- a/addon/content/reducer.js
+++ b/addon/content/reducer.js
@@ -4,10 +4,10 @@
 
 import * as Redux from "redux";
 
-import { messages } from "./reducer-messages.js";
+import { messagesSlice } from "./reducer-messages.js";
 import { summarySlice } from "./reducer-summary.js";
 
 export const conversationApp = Redux.combineReducers({
-  messages,
+  messages: messagesSlice.reducer,
   summary: summarySlice.reducer,
 });


### PR DESCRIPTION
* Merge thunks and actions into `summaryActions`
* Migrates `messages` actions to the RTK-based `createSlice` style.

Several of the reducers were refactors using modern Javascript.

The `msgSetIsJunk` should have the same functionality as the original code, but it seems wrong to me...Is this an unnoticed bug?