### PR TITLE
Work-around for missing "Remote Content" bar (#1453)

### DIFF
--- a/addon/experiment-api/contactsApi.js
+++ b/addon/experiment-api/contactsApi.js
@@ -489,10 +489,10 @@ function waitForWindow(win) {
   });
 }
 
-function monkeyPatchAllWindows(windowManager, callback) {
+function monkeyPatchAllWindows(windowManager, callback, context) {
   for (const win of Services.wm.getEnumerator("mail:3pane")) {
     waitForWindow(win).then(() => {
-      callback(win, windowManager.getWrapper(win).id);
+      callback(win, windowManager.getWrapper(win).id, context);
     });
   }
 }


### PR DESCRIPTION
I was getting `TypeError: context is undefined` on `msgWindowApi.js:364`
(See #1453)

After poking at it a little bit, I discovered that `msgWindowApi.js` is,
for whatever reason, actually calling the `monkeyPatchAllWindows()` from
`contactsApi.js` (!) which doesn't accept/passthru a `context` parameter.

Rather than solve the hard problem of namespacing/scoping the conflicting
function definitions, however, I simply took the path of least resistance
and added the `context` parameter to `contactsApi.js`.  :-}