### PR TITLE
Fixes #1913: Show 'reply all' option if reply-to is different from the sender

### DIFF
--- a/addon/content/reducer/contacts.js
+++ b/addon/content/reducer/contacts.js
@@ -169,7 +169,7 @@ export async function mergeContactDetails(msgData) {
 function hasMultipleRecipients(message) {
   let seen = new Set();
   let count = 0;
-  for (let field of ["from", "to", "cc", "bcc"]) {
+  for (let field of ["from", "to", "cc", "bcc", "replyTo"]) {
     // TODO: The ?? and subsequent !contact currently helps some of the tests to pass.
     let contacts = (field == "from" ? [message[field]] : message[field]) ?? [];
     for (let contact of contacts) {

--- a/addon/content/reducer/messageEnricher.js
+++ b/addon/content/reducer/messageEnricher.js
@@ -421,6 +421,12 @@ export class MessageEnricher {
       );
     }
 
+    if ("reply-to" in fullMsg.headers) {
+      msg.replyTo = await browser.conversations.parseMimeLine(
+        fullMsg.headers["reply-to"][0]
+      );
+    }
+
     function checkPart(msgPart) {
       switch (msgPart.contentType) {
         case "text/html":


### PR DESCRIPTION
Mailing lists with 'Mangle From' configuration swaps 'From' with the mailing list address and keeping the original sender in the 'Reply-To' header.  Currently only 'reply' and 'reply to list' options are available in this case, but there should be an option to reply to both the list and the original sender.

Taking the 'reply-to' header into account while checking for multiple "recipients" to fix the problem.