### PR TITLE
Fix command for a jest test in developer's guide

### DIFF
--- a/docs/Development.md
+++ b/docs/Development.md
@@ -85,7 +85,7 @@ $ npm test
 To run just the *jest* tests, do
 
 ```
-$ npm test:jest
+$ npm run test:jest
 ```
 
 Tests are stored in `test` directories. Because native ESM modules are used while


### PR DESCRIPTION
```
  $ npm test:jest
  Unknown command: "test:jest"

  Did you mean one of these?
    npm run test:lint # run the "test:lint" package script
    npm run test:jest # run the "test:jest" package script
```