### PR TITLE
Use Services global variable

### DIFF
--- a/addon/content/stubWrapper.js
+++ b/addon/content/stubWrapper.js
@@ -4,8 +4,6 @@
 
 "use strict";
 
-var { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
-
 window.addEventListener(
   "load",
   function (event) {


### PR DESCRIPTION
Services.jsm is planned to be removed in Firefox 117 cycle in https://bugzilla.mozilla.org/show_bug.cgi?id=1780695 . Services global variable is in all system globals from version 104 https://bugzilla.mozilla.org/show_bug.cgi?id=1667455 , and those code doesn't have to import Services.jsm if the strict_min_version is 114.