### PR TITLE
Improve appearance of quick reply send button

### DIFF
--- a/addon/content/components/compose/composeWidget.css
+++ b/addon/content/components/compose/composeWidget.css
@@ -73,7 +73,6 @@ input:focus {
   padding: 0.3em 1em;
   background-color: -moz-dialog;
   color: -moz-dialogtext;
-  cursor: pointer;
   border: 1px solid ThreeDShadow;
   border-radius: 3px;
 }

--- a/addon/content/components/compose/composeWidget.css
+++ b/addon/content/components/compose/composeWidget.css
@@ -68,12 +68,17 @@ input:focus {
 }
 
 .compose > .buttons > button {
-  padding: 0 5px;
-  margin-inline-end: 3px;
-  background-color: white;
+  padding: 0.3em 1em;
+  margin-inline-end: 0.2em;
+  background-color: -moz-dialog;
+  color: -moz-dialogtext;
+  cursor: pointer;
   border: 1px solid ThreeDShadow;
-  height: 1.86em;
-  border-radius: 7px;
+  border-radius: 3px;
+}
+
+.compose > .buttons > button:hover {
+  filter: brightness(85%);
 }
 
 #send {

--- a/addon/content/components/compose/composeWidget.css
+++ b/addon/content/components/compose/composeWidget.css
@@ -72,11 +72,21 @@ input:focus {
 .compose > .buttons > button {
   padding: 0.3em 1em;
   background-color: -moz-dialog;
-  color: -moz-dialogtext;
+  color: #666;
   border: 1px solid ThreeDShadow;
   border-radius: 3px;
 }
 
+@media (prefers-color-scheme: dark) {
+  .compose > .buttons > button {
+    color: -moz-fieldtext;
+  }
+}
+
 .compose > .buttons > button:hover {
   filter: brightness(85%);
+}
+
+.compose > .buttons > button > .icon {
+  margin-inline-end: 0.3em;
 }

--- a/addon/content/components/compose/composeWidget.css
+++ b/addon/content/components/compose/composeWidget.css
@@ -64,12 +64,13 @@ input:focus {
 }
 
 .compose > .buttons {
-  margin-top: 10px;
+  padding-top: 10px;
+  display: flex;
+  justify-content: space-between;
 }
 
 .compose > .buttons > button {
   padding: 0.3em 1em;
-  margin-inline-end: 0.2em;
   background-color: -moz-dialog;
   color: -moz-dialogtext;
   cursor: pointer;
@@ -79,8 +80,4 @@ input:focus {
 
 .compose > .buttons > button:hover {
   filter: brightness(85%);
-}
-
-#send {
-  float: inline-end;
 }

--- a/addon/content/components/compose/composeWidget.jsx
+++ b/addon/content/components/compose/composeWidget.jsx
@@ -7,6 +7,7 @@ import React from "react";
 import * as ReactRedux from "react-redux";
 import { TextArea, TextBox } from "./composeFields.jsx";
 import PropTypes from "prop-types";
+import { SvgIcon } from "../svgIcon.jsx";
 
 export function ComposeWidget({ discard }) {
   const dispatch = ReactRedux.useDispatch();
@@ -100,7 +101,9 @@ export function ComposeWidget({ discard }) {
       <div id="sendStatus">{composeState.sendingMsg}</div>
       <div className="buttons">
         <button id="discard" onClick={discard} disabled={!discard}>
-          🗑️ {browser.i18n.getMessage("compose.discard")}
+          <SvgIcon ariaHidden={true} hash="delete_forever" />
+          &nbsp;
+          {browser.i18n.getMessage("compose.discard")}
         </button>
         <button
           id="send"
@@ -109,7 +112,9 @@ export function ComposeWidget({ discard }) {
             composeState.sending || !composeState.to || !composeState.subject
           }
         >
-          📨 {browser.i18n.getMessage("compose.send")}
+          {browser.i18n.getMessage("compose.send")}
+          &nbsp;
+          <SvgIcon ariaHidden={true} hash="send" />
         </button>
       </div>
     </div>

--- a/addon/content/components/compose/composeWidget.jsx
+++ b/addon/content/components/compose/composeWidget.jsx
@@ -100,7 +100,7 @@ export function ComposeWidget({ discard }) {
       <div id="sendStatus">{composeState.sendingMsg}</div>
       <div className="buttons">
         <button id="discard" onClick={discard} disabled={!discard}>
-          {browser.i18n.getMessage("compose.discard")}
+          🗑️ {browser.i18n.getMessage("compose.discard")}
         </button>
         <button
           id="send"
@@ -109,7 +109,7 @@ export function ComposeWidget({ discard }) {
             composeState.sending || !composeState.to || !composeState.subject
           }
         >
-          {browser.i18n.getMessage("compose.send")}
+          📨 {browser.i18n.getMessage("compose.send")}
         </button>
       </div>
     </div>

--- a/addon/content/components/compose/composeWidget.jsx
+++ b/addon/content/components/compose/composeWidget.jsx
@@ -99,11 +99,9 @@ export function ComposeWidget({ discard }) {
       />
       <div id="sendStatus">{composeState.sendingMsg}</div>
       <div className="buttons">
-        {discard && (
-          <a className="link" onClick={discard}>
-            {browser.i18n.getMessage("compose.discard")}
-          </a>
-        )}
+        <button id="discard" onClick={discard} disabled={!discard}>
+          {browser.i18n.getMessage("compose.discard")}
+        </button>
         <button
           id="send"
           onClick={onSend}

--- a/addon/content/components/compose/composeWidget.jsx
+++ b/addon/content/components/compose/composeWidget.jsx
@@ -102,7 +102,6 @@ export function ComposeWidget({ discard }) {
       <div className="buttons">
         <button id="discard" onClick={discard} disabled={!discard}>
           <SvgIcon ariaHidden={true} hash="delete_forever" />
-          &nbsp;
           {browser.i18n.getMessage("compose.discard")}
         </button>
         <button
@@ -112,9 +111,8 @@ export function ComposeWidget({ discard }) {
             composeState.sending || !composeState.to || !composeState.subject
           }
         >
-          {browser.i18n.getMessage("compose.send")}
-          &nbsp;
           <SvgIcon ariaHidden={true} hash="send" />
+          {browser.i18n.getMessage("compose.send")}
         </button>
       </div>
     </div>

--- a/addon/tests/compose.test.jsx
+++ b/addon/tests/compose.test.jsx
@@ -44,7 +44,7 @@ describe("Compose full page tests", () => {
       }
     }
 
-    fireEvent.click(screen.getByRole("button"));
+    fireEvent.click(screen.getByRole("button", { name: /send/i }));
 
     await waitFor(() => {
       if (!mockedSend.mock.calls.length) {


### PR DESCRIPTION
Fixes #1933 

Improve appearance of send button in conversation compose box. Improvements include:
- support for dark mode
- cursor and color change on hover (old design didn't react in any way)
- more padding and boxier design more in line with modern Thunderbird style

Comparison:

Current Light
![before-light](https://github.com/thunderbird-conversations/thunderbird-conversations/assets/26350212/3646376d-ced6-4bc2-ba53-a77d137f7102)

Current Dark
![before-dark](https://github.com/thunderbird-conversations/thunderbird-conversations/assets/26350212/48b3b3df-e181-4bfa-884e-2c2f6c6b84f3)

New Light
![after-light-normal](https://github.com/thunderbird-conversations/thunderbird-conversations/assets/26350212/6c10a40b-7edf-416d-9f2c-453b39a7461f)
![after-light-hover](https://github.com/thunderbird-conversations/thunderbird-conversations/assets/26350212/f4a50b02-e37a-461f-8094-1a3643a5ad93)

New Dark
![after-dark-normal](https://github.com/thunderbird-conversations/thunderbird-conversations/assets/26350212/3ffbbc6f-1e37-4dd3-8727-c0c8e118cf5e)
![after-dark-hover](https://github.com/thunderbird-conversations/thunderbird-conversations/assets/26350212/1328b519-03b2-4429-8c6c-33f17f985e96)

It seems like the surrounding box doesn't resize properly. The bottom edge of the button is close to the border and _maybe_ on some other machines it will stick out. I am not really well versed in HTML and CSS so I don't know how to fix the layout properly. However, this change as it is is still an improvement.

Future improvements should also include changing links `discard`, `Forward this conversation`, `Print this conversation` to button style. It seems like the UI has been neglected and can be easily improved.