### PR TITLE
Fix issue 1611: Add native theme support (& dark mode) to the message display

### DIFF
--- a/addon/content/components/message/messageIFrame.mjs
+++ b/addon/content/components/message/messageIFrame.mjs
@@ -571,9 +571,8 @@ export class MessageIFrame extends React.Component {
   }
 
   injectCss(iframeDoc) {
-    // !important because messageContents.css is appended after us when the html
-    // is rendered
-    return [
+    // Base CSS rules
+    let cssRules = [
       'blockquote[type="cite"] {',
       "  border-right-width: 0px;",
       "  border-left: 1px #ccc solid;",
@@ -583,6 +582,21 @@ export class MessageIFrame extends React.Component {
       "  height: auto;",
       "}",
     ];
+
+    // Additional CSS for dark mode
+    cssRules.push(
+      `@media not print and (prefers-color-scheme: dark){
+          body {
+            filter: invert(100%) hue-rotate(180deg) !important;
+            background: rgb(28, 27, 34) !important;
+          }
+          body :is(img, [style*="background-image:"]:not([style*="background-image: none"]), [background*="."], g-emoji) {
+            filter: invert(100%) hue-rotate(180deg) !important;
+          }
+      }`
+    );
+
+    return cssRules;
   }
 
   async _onDOMLoaded(event) {

--- a/addon/content/components/message/messageIFrame.mjs
+++ b/addon/content/components/message/messageIFrame.mjs
@@ -585,7 +585,7 @@ export class MessageIFrame extends React.Component {
 
     // Additional CSS for dark mode
     cssRules.push(
-      `@media not print and (prefers-color-scheme: dark){
+      `@media screen and (prefers-color-scheme: dark) {
           body {
             filter: invert(100%) hue-rotate(180deg) !important;
             background: rgb(28, 27, 34) !important;


### PR DESCRIPTION
This commit mitigates the issue of dark mode adaptability.

Adding one feature to the options to allow user to enable dark mode. Then the content in the conversation nodes will be adapted.

The solutions is inspired by this comment:
https://github.com/thunderbird-conversations/thunderbird-conversations/issues/1611#issuecomment-2470675052

PS. 
1. I modified all the messages.json under locale, but all are English, feel free to change to the correct language.
2. When I tried to build the project, build.sh does not work well because of the error of `find . -E ...`. The regex expression seems not work, fixed it as well.