### PR TITLE
[codex] Add optional reverse conversation order

### DIFF
--- a/addon/_locales/en/messages.json
+++ b/addon/_locales/en/messages.json
@@ -114,6 +114,16 @@
     "description": "Options - description for hiding the quick reply display."
   },
 
+  "options.reverse_conversation_order_title": {
+    "message": "Newest messages first",
+    "description": "Options - title for reversing the message display order."
+  },
+
+  "options.reverse_conversation_order_desc": {
+    "message": "Display the newest messages at the top of a conversation.",
+    "description": "Options - description for reversing the message display order."
+  },
+
   "options.disable_between_column_title": {
     "message": "Disable Between Column",
     "description": "Options - title for disabling the between column."

--- a/addon/background/prefs.mjs
+++ b/addon/background/prefs.mjs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-export const kCurrentLegacyMigration = 3;
+export const kCurrentLegacyMigration = 4;
 
 export const kPrefDefaults = {
   hide_quote_length: 5,
@@ -15,6 +15,7 @@ export const kPrefDefaults = {
   operate_on_conversations: false,
   extra_attachments: false,
   hide_quick_reply: false,
+  reverse_conversation_order: false,
   compose_in_tab: true,
   unwanted_recipients: "{}",
   hide_sigs: false,
@@ -91,6 +92,10 @@ export class Prefs {
 
     if (currentMigration < 3) {
       prefs.hide_quick_reply = false;
+    }
+
+    if (currentMigration < 4) {
+      prefs.reverse_conversation_order = false;
     }
 
     prefs.migratedLegacy = kCurrentLegacyMigration;

--- a/addon/content/components/message/messageList.mjs
+++ b/addon/content/components/message/messageList.mjs
@@ -6,6 +6,17 @@ import React from "react";
 import * as ReactRedux from "react-redux";
 import { Message } from "./message.mjs";
 
+function getDisplayMessages(msgData, reverseConversationOrder) {
+  if (!msgData) {
+    return [];
+  }
+  return reverseConversationOrder ? [...msgData].reverse() : msgData;
+}
+
+function getQuickReplyTargetId(msgData) {
+  return msgData?.[msgData.length - 1]?.id;
+}
+
 /**
  * Handles display of the list of messages.
  *
@@ -19,6 +30,11 @@ function _MessageList({ dispatch, messages, summary }) {
   // can be called on them in response to a `advanceMessage()`
   // call. The actual ref is stored in `React.useRef().current`
   const { current: childRefs } = React.useRef([]);
+  const displayMessages = getDisplayMessages(
+    messages.msgData,
+    summary.prefs.reverseConversationOrder
+  );
+  const quickReplyTargetId = getQuickReplyTargetId(messages.msgData);
 
   function setRef(index, ref) {
     childRefs[index] = ref;
@@ -35,8 +51,7 @@ function _MessageList({ dispatch, messages, summary }) {
   return React.createElement(
     "ul",
     { id: "messageList" },
-    !!messages.msgData &&
-      messages.msgData.map((message, index) =>
+    displayMessages.map((message, index) =>
         React.createElement(Message, {
           key: index,
           autoMarkAsRead: summary.autoMarkAsRead,
@@ -50,7 +65,7 @@ function _MessageList({ dispatch, messages, summary }) {
           iframesLoading: summary.iframesLoading,
           index,
           isInTab: summary.isInTab,
-          isLastMessage: index == messages.msgData.length - 1,
+          isLastMessage: message.id == quickReplyTargetId,
           isStandalone: summary.isStandalone,
           message,
           tenPxFactor: summary.tenPxFactor,

--- a/addon/content/reducer/controllerActions.mjs
+++ b/addon/content/reducer/controllerActions.mjs
@@ -475,6 +475,8 @@ async function setupUserPreferences(dispatch, getState) {
         expandWho: newPrefs.preferences?.expand_who ?? 4,
         extraAttachments: newPrefs.preferences?.extra_attachments ?? false,
         hideQuickReply: newPrefs.preferences?.hide_quick_reply ?? false,
+        reverseConversationOrder:
+          newPrefs.preferences?.reverse_conversation_order ?? false,
         hideQuoteLength: newPrefs.preferences?.hide_quote_length ?? 5,
         hideSigs: newPrefs.preferences?.hide_sigs ?? false,
         loggingEnabled: newPrefs.preferences?.logging_enabled ?? false,

--- a/addon/content/reducer/reducerSummary.mjs
+++ b/addon/content/reducer/reducerSummary.mjs
@@ -30,6 +30,7 @@ export const initialSummary = {
     expandWho: 4,
     extraAttachments: false,
     hideQuickReply: false,
+    reverseConversationOrder: false,
     hideQuoteLength: 5,
     hideSigs: false,
     loggingEnabled: false,

--- a/addon/options/options.mjs
+++ b/addon/options/options.mjs
@@ -102,6 +102,14 @@ const PREFS_INFO = [
   },
   {
     props: {
+      title: "options.reverse_conversation_order_title",
+      desc: "options.reverse_conversation_order_desc",
+      name: "reverse_conversation_order",
+    },
+    component: "binary-option",
+  },
+  {
+    props: {
       title: "options.disable_between_column_title",
       desc: "options.disable_between_column_desc",
       name: "disableBetweenColumn",

--- a/addon/tests/messageList.test.mjs
+++ b/addon/tests/messageList.test.mjs
@@ -1,0 +1,109 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+// eslint-disable-next-line no-shadow
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import * as RTK from "@reduxjs/toolkit";
+import * as ReactRedux from "react-redux";
+import { MessageList } from "../content/components/message/messageList.mjs";
+import { Message } from "../content/components/message/message.mjs";
+import { conversationApp } from "../content/reducer/reducer.mjs";
+import { messageActions } from "../content/reducer/reducerMessages.mjs";
+import { summaryActions } from "../content/reducer/reducerSummary.mjs";
+
+function stubMessageRendering(t) {
+  const originalRender = Message.prototype.render;
+  const originalDidMount = Message.prototype.componentDidMount;
+  const originalDidUpdate = Message.prototype.componentDidUpdate;
+  const originalWillUnmount = Message.prototype.componentWillUnmount;
+
+  t.after(() => {
+    Message.prototype.render = originalRender;
+    Message.prototype.componentDidMount = originalDidMount;
+    Message.prototype.componentDidUpdate = originalDidUpdate;
+    Message.prototype.componentWillUnmount = originalWillUnmount;
+  });
+
+  Message.prototype.render = function () {
+    return React.createElement(
+      "li",
+      { "data-testid": "message-item" },
+      React.createElement("span", { "data-testid": "message-id" }, this.props.message.id),
+      this.props.isLastMessage &&
+        React.createElement(
+          "span",
+          { "data-testid": "quick-reply-target" },
+          this.props.message.id
+        )
+    );
+  };
+  Message.prototype.componentDidMount = () => {};
+  Message.prototype.componentDidUpdate = () => {};
+  Message.prototype.componentWillUnmount = () => {};
+}
+
+function createStoreWithConversation() {
+  const store = RTK.configureStore({
+    reducer: conversationApp,
+  });
+
+  store.dispatch(
+    messageActions.replaceConversation({
+      messages: [
+        { id: 1, date: 1 },
+        { id: 2, date: 2 },
+        { id: 3, date: 3 },
+      ],
+    })
+  );
+
+  return store;
+}
+
+function renderMessageList(store) {
+  render(
+    React.createElement(
+      ReactRedux.Provider,
+      { store },
+      React.createElement(MessageList)
+    )
+  );
+}
+
+describe("MessageList", () => {
+  it("keeps chronological order by default", async (t) => {
+    stubMessageRendering(t);
+
+    const store = createStoreWithConversation();
+    renderMessageList(store);
+
+    assert.deepEqual(
+      screen.getAllByTestId("message-id").map((item) => Number(item.textContent)),
+      [1, 2, 3]
+    );
+    assert.equal(Number(screen.getByTestId("quick-reply-target").textContent), 3);
+  });
+
+  it("renders newest first and keeps quick reply on the newest message when reverse order is enabled", async (t) => {
+    stubMessageRendering(t);
+
+    const store = createStoreWithConversation();
+    store.dispatch(
+      summaryActions.setUserPreferences({
+        reverseConversationOrder: true,
+      })
+    );
+
+    renderMessageList(store);
+
+    assert.deepEqual(
+      screen.getAllByTestId("message-id").map((item) => Number(item.textContent)),
+      [3, 2, 1]
+    );
+    assert.equal(Number(screen.getByTestId("quick-reply-target").textContent), 3);
+  });
+});

--- a/addon/tests/prefs.test.mjs
+++ b/addon/tests/prefs.test.mjs
@@ -33,6 +33,7 @@ describe("Prefs tests", () => {
         compose_in_tab: false,
       };
       delete newPrefs.hide_quick_reply;
+      delete newPrefs.reverse_conversation_order;
       newPrefs.migratedLegacy = 2;
       await browser.storage.local.set({ preferences: newPrefs });
 
@@ -41,6 +42,7 @@ describe("Prefs tests", () => {
       let stored = (await browser.storage.local.get("preferences")).preferences;
       assert.strictEqual(stored.migratedLegacy, kCurrentLegacyMigration);
       assert.strictEqual(stored.hide_quick_reply, false);
+      assert.strictEqual(stored.reverse_conversation_order, false);
       assert.strictEqual(stored.no_friendly_date, true);
       assert.strictEqual(stored.compose_in_tab, false);
     });


### PR DESCRIPTION
## Summary
- add an optional setting to display the newest conversation messages first
- keep the underlying conversation data in chronological order while deriving display order in the React layer
- keep Quick Reply attached to the newest logical message when reverse order is enabled

## Why
Issue #1900 requests an option to show the newest message at the top of a conversation. The existing implementation assumes chronological storage order in several places, so this change keeps the data model intact and limits the feature to display-order behavior plus the related Quick Reply placement.

## Testing
- NODE_OPTIONS='--import "./addon/tests/setup.mjs"' node --test addon/tests/prefs.test.mjs addon/tests/messageList.test.mjs addon/tests/quickReply.test.mjs addon/tests/options.test.mjs
- npx eslint addon/background/prefs.mjs addon/options/options.mjs addon/_locales/en/messages.json addon/content/reducer/reducerSummary.mjs addon/content/reducer/controllerActions.mjs addon/content/components/message/messageList.mjs addon/tests/prefs.test.mjs addon/tests/messageList.test.mjs
- npm run build
