### PR TITLE
Wrap conversation subjects in vertical and separate views

### DIFF
--- a/addon/content/components/conversation/conversationHeader.mjs
+++ b/addon/content/components/conversation/conversationHeader.mjs
@@ -409,6 +409,12 @@ export class ConversationHeader extends HTMLElement {
     if (this.#linkifiedSubject.getAttribute("subject") != summary.subject) {
       this.#linkifiedSubject.setAttribute("subject", summary.subject);
     }
+    this.#linkifiedSubject.toggleAttribute(
+      "wrap",
+      summary.isVerticalLayout === true ||
+        summary.isInTab === true ||
+        summary.isStandalone === true
+    );
     if (
       this.#convActionButtons.getAttribute("darkreaderenabled") !=
       summary.darkReaderEnabled.toString()

--- a/addon/content/conversation.css
+++ b/addon/content/conversation.css
@@ -146,6 +146,14 @@ a img {
   text-overflow: ellipsis;
 }
 
+:host([wrap]) .subject {
+  height: auto;
+  overflow: visible;
+  overflow-wrap: anywhere;
+  white-space: normal;
+  text-overflow: clip;
+}
+
 linkified-subject {
   flex: 1;
   overflow: hidden;

--- a/addon/content/reducer/controllerActions.mjs
+++ b/addon/content/reducer/controllerActions.mjs
@@ -75,10 +75,17 @@ export const controllerActions = {
         tabId = isStandalone ? null : BrowserSim.getTabId(topWin, window);
       }
 
+      let isVerticalLayout = false;
+      if (!isInTab && tabId != null) {
+        isVerticalLayout =
+          (await browser.mailTabs.get(tabId)).layout === "vertical";
+      }
+
       await dispatch(
         summaryActions.setConversationState({
           isInTab,
           isStandalone,
+          isVerticalLayout,
           tabId,
           windowId,
         })

--- a/addon/content/reducer/controllerActions.mjs
+++ b/addon/content/reducer/controllerActions.mjs
@@ -160,6 +160,22 @@ export const controllerActions = {
     };
   },
 
+  updateConversationLayout() {
+    return async (dispatch, getState) => {
+      const { isInTab, isStandalone, tabId } = getState().summary;
+      if (isInTab || isStandalone || tabId == null) {
+        return;
+      }
+
+      const { layout } = await browser.mailTabs.get(tabId);
+      dispatch(
+        summarySlice.actions.setVerticalLayout({
+          isVerticalLayout: layout === "vertical",
+        })
+      );
+    };
+  },
+
   /**
    * Handles potentially marking a conversation as read.
    */
@@ -433,6 +449,10 @@ function setupListeners(dispatch, getState) {
   let port = browser.runtime.connect({ name: "externalMessages" });
   let externalMessagesListener = onExternalMessages.bind(this, dispatch);
   port.onMessage.addListener(externalMessagesListener);
+  const layoutChangedListener = () => {
+    dispatch(controllerActions.updateConversationLayout()).catch(console.error);
+  };
+  window.addEventListener("resize", layoutChangedListener);
 
   window.addEventListener(
     "unload",
@@ -459,6 +479,7 @@ function setupListeners(dispatch, getState) {
       browser.convOpenPgp.onSMIMEReload.removeListener(smimeReloadListener);
       port.onMessage.removeListener(externalMessagesListener);
       port.disconnect();
+      window.removeEventListener("resize", layoutChangedListener);
     },
     { once: true }
   );

--- a/addon/content/reducer/reducerSummary.mjs
+++ b/addon/content/reducer/reducerSummary.mjs
@@ -15,6 +15,7 @@ export const initialSummary = {
   iframesLoading: 0,
   isInTab: false,
   isStandalone: false,
+  isVerticalLayout: false,
   // TODO: What is loading used for?
   loading: true,
   messageNotFound: false,
@@ -277,8 +278,16 @@ export const summarySlice = RTK.createSlice({
       };
     },
     setConversationState(state, { payload }) {
-      const { isInTab, isStandalone, tabId, windowId } = payload;
-      return { ...state, isInTab, isStandalone, tabId, windowId };
+      const { isInTab, isStandalone, isVerticalLayout, tabId, windowId } =
+        payload;
+      return {
+        ...state,
+        isInTab,
+        isStandalone,
+        isVerticalLayout,
+        tabId,
+        windowId,
+      };
     },
     setDarkReaderEnabled(state, { payload }) {
       return { ...state, darkReaderEnabled: payload.darkReaderEnabled };

--- a/addon/content/reducer/reducerSummary.mjs
+++ b/addon/content/reducer/reducerSummary.mjs
@@ -289,6 +289,9 @@ export const summarySlice = RTK.createSlice({
         windowId,
       };
     },
+    setVerticalLayout(state, { payload }) {
+      return { ...state, isVerticalLayout: payload.isVerticalLayout };
+    },
     setDarkReaderEnabled(state, { payload }) {
       return { ...state, darkReaderEnabled: payload.darkReaderEnabled };
     },

--- a/addon/tests/conversationHeader.test.mjs
+++ b/addon/tests/conversationHeader.test.mjs
@@ -1,0 +1,68 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import "./setup.mjs";
+import assert from "node:assert/strict";
+import { before, describe, it } from "node:test";
+import { ConversationHeader } from "../content/components/conversation/conversationHeader.mjs";
+
+describe("ConversationHeader", () => {
+  before(() => {
+    window.matchMedia = () => ({
+      matches: false,
+      addEventListener() {},
+    });
+    ConversationHeader.dispatch = () => {};
+  });
+
+  function renderHeader() {
+    const header = document.createElement("conversation-header");
+    document.body.appendChild(header);
+    return header;
+  }
+
+  function setView(header, view = {}) {
+    header.setData(
+      {
+        darkReaderEnabled: false,
+        isInTab: false,
+        isStandalone: false,
+        isVerticalLayout: false,
+        loading: false,
+        subject: "A subject long enough to need more than one line",
+        ...view,
+      },
+      []
+    );
+  }
+
+  it("wraps only in vertical, separate-tab, and standalone views", (t) => {
+    const header = renderHeader();
+    t.after(() => header.remove());
+    const subject = header.shadowRoot.querySelector("linkified-subject");
+
+    setView(header);
+    assert.equal(subject.hasAttribute("wrap"), false);
+
+    setView(header, { isVerticalLayout: true });
+    assert.equal(
+      subject.hasAttribute("wrap"),
+      true,
+      "full subject should wrap in vertical and separate views"
+    );
+
+    setView(header);
+    assert.equal(
+      subject.hasAttribute("wrap"),
+      false,
+      "returning to the classic layout should restore subject truncation"
+    );
+
+    setView(header, { isInTab: true });
+    assert.equal(subject.hasAttribute("wrap"), true);
+
+    setView(header, { isStandalone: true });
+    assert.equal(subject.hasAttribute("wrap"), true);
+  });
+});

--- a/addon/tests/reducerController.test.mjs
+++ b/addon/tests/reducerController.test.mjs
@@ -10,6 +10,7 @@ import * as RTK from "@reduxjs/toolkit";
 import * as Redux from "redux";
 
 import { conversationActions } from "../content/reducer/reducerConversation.mjs";
+import { controllerActions } from "../content/reducer/controllerActions.mjs";
 import {
   messageActions,
   messagesSlice,
@@ -34,6 +35,31 @@ describe("Controller Actions tests", () => {
     t.mock
       .method(browser.messages, "get")
       .mock.mockImplementation(async (id) => fakeMessageHeaderData.get(id));
+  });
+
+  describe("updateConversationLayout", () => {
+    it("refreshes the cached layout after the message pane resizes", async (t) => {
+      const mailTabsGet = t.mock.method(browser.mailTabs, "get");
+      await store.dispatch(
+        summaryActions.setConversationState({
+          isInTab: false,
+          isStandalone: false,
+          isVerticalLayout: false,
+          tabId: 7,
+          windowId: 8,
+        })
+      );
+
+      mailTabsGet.mock.mockImplementation(async () => ({
+        layout: "vertical",
+      }));
+      await store.dispatch(controllerActions.updateConversationLayout());
+      assert.equal(store.getState().summary.isVerticalLayout, true);
+
+      mailTabsGet.mock.mockImplementation(async () => ({ layout: "classic" }));
+      await store.dispatch(controllerActions.updateConversationLayout());
+      assert.equal(store.getState().summary.isVerticalLayout, false);
+    });
   });
 
   describe("displayConversationMsgs", () => {


### PR DESCRIPTION
## Summary

- preserve single-line subject truncation in the classic three-pane layout
- show the full subject across lines in vertical layout, separate tabs, and standalone windows
- refresh the cached conversation layout after Thunderbird layout changes
- cover both view-specific wrapping and live classic/vertical transitions

## Checks

- `OPENSSL_CONF=/dev/null node --test addon/tests/conversationHeader.test.mjs addon/tests/reducerController.test.mjs` (base failed and corrected commit passed in the clean network-off verifier)
- `npm test` (90/90 tests passed, including lint, TypeScript, formatting, and Node tests)
- `npm run build` (webpack and XPI build completed; existing raw-component copy warnings remain)
- Thunderbird 152.0.1 manual UI matrix: classic, vertical, separate-tab, and standalone-window views passed; live classic -> vertical -> classic updates passed in the same open conversation

Fixes #2049

---
AI assistance was used. This change was reviewed by Northset, and I accept responsibility for this submission.

<!-- northset-receipt:M-1025:start -->
### Verification

[Northset proof-of-pass receipt M-1025](https://northset-oss.github.io/verification-pilot/receipts/M-1025/)  
Contributor self-run; not maintainer verification.
<!-- northset-receipt:M-1025:end -->
